### PR TITLE
fix(rest-client): updated axios to 1.7.3

### DIFF
--- a/packages/rest-client/utils/versions.ts
+++ b/packages/rest-client/utils/versions.ts
@@ -1,4 +1,4 @@
-export const AXIOS_VERSION = '1.6.8';
+export const AXIOS_VERSION = '1.7.3';
 export const ORVAL_VERSION = '6.28.2';
 export const MSW_VERSION = '2.2.14';
 export const FAKERJS_VERSION = '8.4.1';


### PR DESCRIPTION
Axios version embeeded in TypeScript file needed bumping

#### 📲 What

Bump Axios in TypeScript file.

#### 🤔 Why

Version pulled in dynamically.

#### 🛠 How

N/A

#### 👀 Evidence

```
   √  nx run common-test:test  [local cache]
   √  nx run workspace:test  [local cache]
   √  nx run cypress:test  [local cache]
   √  nx run next:test  [local cache]
   √  nx run azure-react:test  [local cache]
   √  nx run common-core:test  [local cache]
   √  nx run playwright:test  [local cache]
   √  nx run create:test  [local cache]
   √  nx run azure-node:test  [local cache]
   √  nx run logger:test  [local cache]
   √  nx run rest-client:test (6s)
```

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
