### PR TITLE
fix(root): bump axios and elliptic versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9791,9 +9791,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-            "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -13626,9 +13626,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.6",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-            "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+            "version": "6.5.7",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     },
     "dependencies": {
         "@swc/helpers": "0.5.11",
-        "axios": "^1.7.3",
+        "axios": "^1.7.4",
         "chalk": "4.1.0",
         "change-case": "4.1.2",
         "enquirer": "2.3.6",

--- a/packages/rest-client/utils/versions.ts
+++ b/packages/rest-client/utils/versions.ts
@@ -1,4 +1,4 @@
-export const AXIOS_VERSION = '1.7.3';
+export const AXIOS_VERSION = '1.7.4';
 export const ORVAL_VERSION = '6.28.2';
 export const MSW_VERSION = '2.2.14';
 export const FAKERJS_VERSION = '8.4.1';


### PR DESCRIPTION
- Axios 1.7.3 → 1.7.4 resolves CVE-2024-39338
- elliptic 6.5.6 → 6.5.7 resolves CVE-2024-42459, CVE-2024-42460 and CVE-2024-42461

#### 📲 What

Updated using `npm audit fix` bumps the versions of both Axios and Elliptic to non-vulnerable versions. Additionally updated Axios version in rest-client.

#### 🤔 Why

We are committed to resolving Critical, High and Medium vulnerabilities within a reasonable timeframe within Stacks to meet our obligations under ISO 27001, CyberEssentials Plus and numerous commitments to clients.

#### 🛠 How

- `npm audit fix` bump axios and elliptic in `package.json`
- direct change of CONST in `AXIOS_VERSION`

#### 👀 Evidence

```
   √  nx run common-test:lint  [existing outputs match the cache, left as is]
   √  nx run common-core:lint  [existing outputs match the cache, left as is]
   √  nx run playwright:lint  [existing outputs match the cache, left as is]
   √  nx run workspace:lint  [existing outputs match the cache, left as is]
   √  nx run cypress:lint  [existing outputs match the cache, left as is]
   √  nx run create:lint  [existing outputs match the cache, left as is]
   √  nx run common-e2e:lint  [existing outputs match the cache, left as is]
   √  nx run next:lint  [existing outputs match the cache, left as is]
   √  nx run azure-react:lint  [existing outputs match the cache, left as is]
   √  nx run azure-node:lint  [existing outputs match the cache, left as is]
   √  nx run logger:lint  [existing outputs match the cache, left as is]
   √  nx run rest-client:lint (4s)
```

#### 🕵️ How to test

Checkout code and run.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
