### PR TITLE
ci(root): move node setup to after checkout

### DIFF
--- a/.github/workflows/matrix-command.yml
+++ b/.github/workflows/matrix-command.yml
@@ -1,0 +1,48 @@
+name: Matrix Nx Command
+on:
+  workflow_dispatch:
+    inputs:
+      nx-command:
+        description: 'Nx Command to run'
+        default: 'run-many --target=e2e'
+      node-version:
+        description: 'Node version to use'
+        type: 'number'
+        default: 22
+      number-of-agents:
+        description: 'Number of Agents to use'
+        type: 'number'
+        default: 3
+jobs:
+  command:
+    permissions:
+      contents: read
+    name: Matrix Command
+    uses: ./.github/workflows/main.yml
+    with:
+      runs-on: ubuntu-latest
+      node-version: ${{ inputs.node-version }}
+      number-of-agents: ${{ inputs.number-of-agents }}
+      parallel-commands-on-agents: |
+        npx nx ${{ inputs.nx-command }}
+      environment-variables: |
+        NX_E2E_CI_CACHE_KEY=e2e-gha
+        NODE_OPTIONS=--max_old_space_size=8192
+        NX_VERBOSE_LOGGING=${{ 'true' }}
+        NX_E2E_SKIP_BUILD_CLEANUP=${{ 'true' }}
+        NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc
+        NX_RUN_GROUP=${{ github.run_id }}
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  agents:
+    name: Nx Cloud - Agents
+    uses: ./.github/workflows/agents.yml
+    with:
+      runs-on: ubuntu-latest
+      node-version: ${{ inputs.node-version }}
+      number-of-agents: ${{ inputs.number-of-agents }}
+      environment-variables: |
+        NX_RUN_GROUP=${{ github.run_id }}
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,14 +9,14 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.BOT_TOKEN }}
+    
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
 
     - name: Setup git user
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.BOT_TOKEN }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
 
     - name: Setup git user
       shell: bash


### PR DESCRIPTION
#### 📲 What

With migration from Volta to node we want to leverage `.nvmrc` to install the correct node version.
That means we need to checkout the code first before setting up node 😄 

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
