### PR TITLE
ci(root): attempt fix for commits not associated to branch

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: main
         fetch-depth: 0
         token: ${{ secrets.BOT_TOKEN }}
     
@@ -55,6 +56,6 @@ jobs:
       uses: ad-m/github-push-action@552c074ed701137ebd2bf098e70c394ca293e87f
       with:
         github_token: ${{ secrets.BOT_TOKEN }}
-        branch: ${{ github.ref }}
+        branch: main
         force: true
         tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: main
         fetch-depth: 0
         token: ${{ secrets.BOT_TOKEN }}
 
@@ -55,6 +56,6 @@ jobs:
       uses: ad-m/github-push-action@552c074ed701137ebd2bf098e70c394ca293e87f
       with:
         github_token: ${{ secrets.BOT_TOKEN }}
-        branch: ${{ github.ref }}
+        branch: main
         force: true
         tags: true


### PR DESCRIPTION
#### 📲 What

Commits raised in CI do not belong to any branches.
Not quite sure why, but believe it to be a combination of not specifying the ref in checkout and branch protection.
Explicitly calling the ref, I hope to see tags associated to commits that belong to a branch.

#### 🤔 Why

When we do a release we gather tags from commits. It will not observe commits that do not belong to any branches, resulting in the incorrect semver version produced which causes catastrophic failure when trying to push the same version up to npm.

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/046af12d-ce87-439a-8951-508dd4f4a965">

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
